### PR TITLE
Remove branch from script

### DIFF
--- a/db/clone-data-repo.sh
+++ b/db/clone-data-repo.sh
@@ -17,7 +17,7 @@ if test -f "$FILE"; then
 
         # even though this repo is actually public the data heavily depends on the data of qc-atlas
         # therefore it is only loaded if the atlas repo was sucessfully cloned
-        git clone --branch old ${NISQ_CONTENT_REPOSITORY_URL} ${NISQ_CONTENT_REPOSITORY_PATH}
+        git ${NISQ_CONTENT_REPOSITORY_URL} ${NISQ_CONTENT_REPOSITORY_PATH}
         if [ -d "${NISQ_CONTENT_REPOSITORY_PATH}/${NISQ_SUBFOLDER_CONTENT_BACKUP_FILES}" ]; then
             cp setup-nisq.sh /docker-entrypoint-initdb.d/
             echo "nisq-analyzer-content repo was cloned successfully"


### PR DESCRIPTION
Previously a specific branch of the nisq analyzer content repository was used. This should have only been temporary.
As soon as this [pull request](https://github.com/UST-QuAntiL/nisq-analyzer-content/pull/1) in the nisq analyzer content repository is merged the proposed changes will work.