### PR TITLE
fix patternatlas setup 

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,13 @@ A detailed documentation can be found [here](https://quantil.readthedocs.io/en/l
 The fastest way to get started is using [Docker Compose](https://docs.docker.com/compose/).  
 
 The base components QC Atlas, QC Atlas UI, LaTeX Renderer, and the databases without any of the named features run by default using:
-  ```shell
-  docker-compose pull
-  docker-compose up db -d
-  docker-compose up
-  ```
-The database (db) needs to be started first to ensure that its initialization finshed before the other containers connect to it. 
+```shell 
+ docker-compose pull
+ docker-compose up db -d
+ docker-compose up
+ ```
+  
+⚠️ The database (db) needs to be started first in the second step to ensure that its initialization finshed before the other containers connect to it. 
 
 For running certain feature sets on top of the base components, [Profiles](https://docs.docker.com/compose/profiles/) are used.  
 To start a certain feature set run:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The base components QC Atlas, QC Atlas UI, LaTeX Renderer, and the databases wit
  docker-compose up
  ```
   
-> ⚠️ The database (db) must be started before the other containers to ensure that it was fully initialized. Otherwise the other containers may fail to start."
+> ⚠️ The database (db) must be started before the other containers to ensure that it was fully initialized. Otherwise the other containers may fail to start.
 
 For running certain feature sets on top of the base components, [Profiles](https://docs.docker.com/compose/profiles/) are used.  
 To start a certain feature set run:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The base components QC Atlas, QC Atlas UI, LaTeX Renderer, and the databases wit
  docker-compose up
  ```
   
-⚠️ The database (db) needs to be started first in the second step to ensure that its initialization finshed before the other containers connect to it. 
+> ⚠️ The database (db) needs to be started first in the second step to ensure that its initialization finshed before the other containers connect to it. 
 
 For running certain feature sets on top of the base components, [Profiles](https://docs.docker.com/compose/profiles/) are used.  
 To start a certain feature set run:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The fastest way to get started is using [Docker Compose](https://docs.docker.com
 The base components QC Atlas, QC Atlas UI, LaTeX Renderer, and the databases without any of the named features run by default using:
   ```shell
   docker-compose pull
-  docker-compose up db
+  docker-compose up db -d
   docker-compose up
   ```
 The database (db) needs to be started first to ensure that its initialization finshed before the other containers connect to it. 
@@ -30,14 +30,14 @@ For running certain feature sets on top of the base components, [Profiles](https
 To start a certain feature set run:
   ```shell
   docker-compose --profile <name-of-feature-set> pull
-  docker-compose up db
+  docker-compose up db -d
   docker-compose --profile <name-of-feature-set> up
   ```
   
 For running multiple feature sets, e.g. two sets, run:
   ```shell
   docker-compose --profile <name-of-feature-set-1> --profile <name-of-feature-set-2> pull
-  docker-compose --profile <name-of-feature-set-1> up db
+  docker-compose --profile <name-of-feature-set-1> up db -d
   docker-compose --profile <name-of-feature-set-1> --profile <name-of-feature-set-2> up db
   ```
   

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The base components QC Atlas, QC Atlas UI, LaTeX Renderer, and the databases wit
  docker-compose up
  ```
   
-> ⚠️ The database (db) needs to be started first in the second step to ensure that its initialization is finished before the other containers connect to it. 
+> ⚠️ The database (db) must be started before the other containers to ensure that it was fully initialized. Otherwise the other containers may fail to start."
 
 For running certain feature sets on top of the base components, [Profiles](https://docs.docker.com/compose/profiles/) are used.  
 To start a certain feature set run:

--- a/README.md
+++ b/README.md
@@ -21,19 +21,24 @@ The fastest way to get started is using [Docker Compose](https://docs.docker.com
 The base components QC Atlas, QC Atlas UI, LaTeX Renderer, and the databases without any of the named features run by default using:
   ```shell
   docker-compose pull
+  docker-compose up db
   docker-compose up
   ```
+The database (db) needs to be started first to ensure that its initialization finshed before the other containers connect to it. 
+
 For running certain feature sets on top of the base components, [Profiles](https://docs.docker.com/compose/profiles/) are used.  
 To start a certain feature set run:
   ```shell
   docker-compose --profile <name-of-feature-set> pull
+  docker-compose up db
   docker-compose --profile <name-of-feature-set> up
   ```
   
 For running multiple feature sets, e.g. two sets, run:
   ```shell
   docker-compose --profile <name-of-feature-set-1> --profile <name-of-feature-set-2> pull
-  docker-compose --profile <name-of-feature-set-1> --profile <name-of-feature-set-2> up
+  docker-compose --profile <name-of-feature-set-1> up db
+  docker-compose --profile <name-of-feature-set-1> --profile <name-of-feature-set-2> up db
   ```
   
 For running all feature sets, choose `--profile all`.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The base components QC Atlas, QC Atlas UI, LaTeX Renderer, and the databases wit
  docker-compose up
  ```
   
-> ⚠️ The database (db) needs to be started first in the second step to ensure that its initialization finshed before the other containers connect to it. 
+> ⚠️ The database (db) needs to be started first in the second step to ensure that its initialization is finished before the other containers connect to it. 
 
 For running certain feature sets on top of the base components, [Profiles](https://docs.docker.com/compose/profiles/) are used.  
 To start a certain feature set run:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,8 @@ services:
       JDBC_DATABASE_USERNAME: patternatlas
       JDBC_DATABASE_PASSWORD: patternatlas
       JDBC_DATABASE_PORT: 5060
+      LATEX_RENDERER_HOST_NAME: latex-renderer
+      LATEX_RENDERER_PORT: 5030
       API_PORT: 1977
     ports:
       - '1977:1977'


### PR DESCRIPTION
Fix the --profile=patternAtlas setup by 
- documenting that the db needs to be started before all other containers
- including missing env properties