### PR TITLE
Add PlanQK-Library to docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,14 @@ For running the feature set `winery`, the setup needs additional configuration:
 | Config-Server               | <http://localhost:2379>               | [Link](https://github.com/etcd-io/etcd)                   | [Link](https://quay.io/repository/coreos/etcd)                         |
 | Winery                      | <http://localhost:8080>               | [Link](https://github.com/eclipse/winery)                 | [Link](https://hub.docker.com/r/opentosca/winery)                      |
 | QHAna Plugin Runner         |<http://localhost:5005>                | [Link](https://github.com/UST-QuAntiL/qhana-plugin-runner) | [Link](https://github.com/UST-QuAntiL/qhana-plugin-runner/pkgs/container/qhana-plugin-runner) |
+| PlanQK Library              |<http://localhost:2903>                | [Link](https://github.com/UST-QuAntiL/PlanQK-Library) | [Link](https://hub.docker.com/repository/docker/planqk/planqk-library) |
 
 **Make sure following ports in your environment are free in order to start the QuAntiL environment properly:**
 
 * `80`
 * `1977`
 * `1978`
+* `2903`
 * `2379`
 * `5005`
 * `5010`-`5017`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,6 +68,12 @@ services:
       - "6626:6626"
     networks:
       - default
+  library:
+    image: planqk/planqk-library:latest
+    ports:
+      - "2903:2903"
+    networks:
+      - default
   winery:
     image: opentosca/winery:latest
     profiles: ["all", "winery"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,9 @@ services:
       QPROV_PORT: 5020
       LATEX_RENDERER_HOST_NAME: localhost
       LATEX_RENDERER_PORT: 5030
+      LIBRARY_HOST_NAME: localhost
+      LIBRARY_PORT: 2903
+
     ports:
       - '80:80'
     volumes:


### PR DESCRIPTION
This PR adds the PlanQK-Library service to docker-compose.