### PR TITLE
Add section to readme for IBMQ token

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,11 @@ docker-compose logs -f [--tail=1 <SERVICE_NAME>...]
 docker-compose logs -f qc-atlas db
 ```
 
+### Setup IBMQ Token for QProv
+
+QProv requires you IBMQ Token to collect provenance data from IBM's QPUs.
+To provide your token add it to the `_docker-compose.override.yml` at `services/qprov-collector-ibm/environment/QPROV_IBMQ_TOKEN`.
+
 ### Import Example Data
 
 See [QuAntil documentation](https://ust-quantil.github.io/quantil-docs/developer-guide/docker/)

--- a/_docker-compose.override.yml
+++ b/_docker-compose.override.yml
@@ -16,7 +16,7 @@ services:
 
   qprov-collector-ibm:
     environment:
-      QPROV_IBMQ_TOKEN: ''
+      QPROV_IBMQ_TOKEN: '<Place your token here>'
 
 secrets:
   ssh_secret:


### PR DESCRIPTION
Adds a section to the readme on where to place the users IBMQ token.
Additionally change the empty default value in config to make it even clearer.