### PR TITLE
Fixed issue with coreos etcd config server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -351,18 +351,18 @@ services:
     networks:
       - default
   config-server:
-    image: quay.io/coreos/etcd:latest
+    image: quay.io/coreos/etcd:v3.5.9
     environment:
       ETCD_NAME: config-node1
       ETCD_CORS: "*"
+      ETCD_ENABLE_V2: 'true'
+      ETCDCTL_API: 3
       ETCD_ADVERTISE_CLIENT_URLS: "http://config-server:2379"
       ETCD_LISTEN_CLIENT_URLS: "http://0.0.0.0:2379"
-      ETCDCTL_API: 3
     ports:
       - "2379:2379"
     networks:
       - default
-
   # QHana containers
   qhana-ui:
     image: ghcr.io/ust-quantil/qhana-ui:main


### PR DESCRIPTION
Fix issue with calling the V2 API for the latest version of etcd config server by enabling the V2 API.